### PR TITLE
Fix version being more than 32 characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ packagecache
 /repo/
 /flatpak/
 .vscode/*
+
+# Ignore snap build
+*.snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -198,7 +198,7 @@ parts:
     parse-info: [usr/share/metainfo/com.usebottles.bottles.appdata.xml]
     override-pull: |
       craftctl default
-      craftctl set version=$(git describe --tags --abbrev=8)
+      craftctl set version=$(git describe --tags --abbrev=8|awk -F "-" {'print $1"-"$5'})
       sed -i -e 's|@PYTHON@|/usr/bin/python3|g' src/bottles.in
     build-packages:
       - python3


### PR DESCRIPTION
# Description
Fixed version being too long and added a .gitignore for .snap builds

Fixes #(issue)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce.
- [ ] `snapcraft`
- [ ] It snaps and doesn't fail :)
